### PR TITLE
Update tailwind directives for v4

### DIFF
--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -1,0 +1,41 @@
+import { useState, useEffect } from 'react';
+import useThemeStore from '../store/themeStore';
+
+const ThemeToggle = () => {
+  const { isDarkMode, toggleDarkMode } = useThemeStore();
+  const [mounted, setMounted] = useState(false);
+
+  // Avoid hydration mismatch
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return (
+      <button className="w-10 h-6 bg-gray-300 rounded-full relative transition-colors duration-200">
+        <div className="w-4 h-4 bg-white rounded-full absolute top-1 left-1 transition-transform duration-200"></div>
+      </button>
+    );
+  }
+
+  return (
+    <button
+      onClick={toggleDarkMode}
+      className={`w-10 h-6 rounded-full relative transition-colors duration-200 ${
+        isDarkMode ? 'bg-blue-600' : 'bg-gray-300'
+      }`}
+      aria-label="Toggle dark mode"
+    >
+      <div
+        className={`w-4 h-4 bg-white rounded-full absolute top-1 transition-transform duration-200 ${
+          isDarkMode ? 'translate-x-4' : 'translate-x-0'
+        }`}
+      ></div>
+      <span className="sr-only">
+        {isDarkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      </span>
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,1 +1,13 @@
-@import "tailwindcss";
+@tailwind base;
+@tailwind utilities;
+
+/* Dark mode custom styles */
+@layer base {
+  html {
+    @apply transition-colors duration-300;
+  }
+  
+  body {
+    @apply bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 transition-colors duration-300;
+  }
+}

--- a/frontend/src/store/themeStore.js
+++ b/frontend/src/store/themeStore.js
@@ -1,0 +1,42 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+const useThemeStore = create(
+  persist(
+    (set) => ({
+      isDarkMode: false,
+      toggleDarkMode: () => set((state) => {
+        const newMode = !state.isDarkMode;
+        // Apply theme to document
+        if (newMode) {
+          document.documentElement.classList.add('dark');
+        } else {
+          document.documentElement.classList.remove('dark');
+        }
+        return { isDarkMode: newMode };
+      }),
+      setDarkMode: (isDark) => set(() => {
+        // Apply theme to document
+        if (isDark) {
+          document.documentElement.classList.add('dark');
+        } else {
+          document.documentElement.classList.remove('dark');
+        }
+        return { isDarkMode: isDark };
+      }),
+    }),
+    {
+      name: 'theme-storage',
+      onRehydrateStorage: () => (state) => {
+        // Apply stored theme on app load
+        if (state?.isDarkMode) {
+          document.documentElement.classList.add('dark');
+        } else {
+          document.documentElement.classList.remove('dark');
+        }
+      },
+    }
+  )
+);
+
+export default useThemeStore;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,4 +1,5 @@
 export default {
+  darkMode: 'class',
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
Fix Tailwind CSS v4 `@tailwind components` error and add class-based dark mode with a theme toggle.

---
<a href="https://cursor.com/background-agent?bcId=bc-705ea3e7-9075-4ac4-a10d-1669ce120c43">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-705ea3e7-9075-4ac4-a10d-1669ce120c43">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

